### PR TITLE
Fix error when running Hatband tests in a project

### DIFF
--- a/armstrong/hatband/tests/sites.py
+++ b/armstrong/hatband/tests/sites.py
@@ -160,7 +160,7 @@ class TypeAndModelToQueryViewTestCase(HatbandViewTestCase):
 
     @staff_login
     def test_returns_string_suitable_for_display_in_gfk_widget(self):
-        content_type = ContentType.objects.all()[0]
+        content_type = ContentType.objects.get_for_model(User)
         obj = content_type.model_class().objects.all()[0]
         response = self.client.get(self.url, {
                 "content_type_id": content_type.pk,


### PR DESCRIPTION
The test case changed was pulling the first content type, which possibly didn't have any objects.
