### PR TITLE
Streamline syntax, AJAX requests and error responses

### DIFF
--- a/armstrong/hatband/static/generickey.js
+++ b/armstrong/hatband/static/generickey.js
@@ -5,16 +5,16 @@ armstrong.constants = armstrong.constants || {};
 armstrong.constants.hasWarn = typeof console !== "undefined" && typeof console.warn === "function";
 
 armstrong.widgets.generickey = function($, options) {
-  var id = options.id,
-      object_id_name = options.object_id_name || "object_id",
-      content_type_name = options.content_type_name || "content_type",
-      object_id_input = $("#" + id),
-      pk_input = $("#" + id.replace(object_id_name, "id")),
+  var id                 = options.id,
+      object_id_name     = options.object_id_name || "object_id",
+      content_type_name  = options.content_type_name || "content_type",
+      object_id_input    = $("#" + id),
+      pk_input           = $("#" + id.replace(object_id_name, "id")),
       content_type_input = $("#" + id.replace(object_id_name, content_type_name)),
-      container = $("#generic_key_" + id),
-      row = container.parents("tr"),
-      searchDone = options.searchDone || $.noop,
-      params = {
+      container          = $("#generic_key_" + id),
+      row                = container.parents("tr"),
+      searchDone         = options.searchDone || $.noop,
+      params             = {
         object_id: row.find("." + object_id_name + ' input[type="hidden"]').val(),
         content_type_id: row.find("." + content_type_name + " input").val()
       };
@@ -23,7 +23,7 @@ armstrong.widgets.generickey = function($, options) {
       var facets = {
         inFlight: false,
         data: [],
-        raw: false,
+        raw: false
       };
       options.query = options.query || '';
       var app = VS.init({
@@ -40,7 +40,7 @@ armstrong.widgets.generickey = function($, options) {
           search : function(query) {
             var isNumber = function(n) {
               return !isNaN(parseFloat(n)) && isFinite(n);
-            }
+            };
             if (query.length <= 0) {
               return;
             }
@@ -62,7 +62,7 @@ armstrong.widgets.generickey = function($, options) {
               facets.inFlight = true;
               $.getJSON(options.facetURL, function(data) {
                 facets.raw = data;
-                for (key in data) {
+                for (var key in data) {
                   facets.data.push(key);
                 }
                 callback(facets.data, true);
@@ -99,7 +99,7 @@ armstrong.widgets.generickey = function($, options) {
 
   if (params.content_type_id) {
     $.getJSON(options.queryLookupURL, params, function(data) {
-      options.query = data.query
+      options.query = data.query;
       return initVisualSearch();
       });
   } else {

--- a/armstrong/hatband/static/hatband/js/backbone-inline-base.js
+++ b/armstrong/hatband/static/hatband/js/backbone-inline-base.js
@@ -13,7 +13,7 @@ Item = Backbone.Model.extend({
     },
     readInput: function(input) {
         input = $(input);
-        var value = {}
+        var value = {};
         value[input.attr('name').substr(this.attributes.prefix.length)] = input.val();
         this.set(value, {silent: true});
     },
@@ -37,7 +37,7 @@ ItemList = Backbone.Collection.extend({
             var obj = new this.model({prefix: el.id+"-"});
             this.add(obj);
         }, this));
-    },
+    }
 });
 
 ManagementForm = Backbone.View.extend({
@@ -49,11 +49,11 @@ ManagementForm = Backbone.View.extend({
     update: function() {
         $("#id_"+this.options.namespace+"-TOTAL_FORMS").val(this.options.collection.length);
     }
-})
+});
 
 EmptyForm = Backbone.View.extend({
     elements: function() {
-        return this.$('input[id*="__prefix__"]')
+        return this.$('input[id*="__prefix__"]');
     },
     cloneForm: function(formId) {
         return this.elements().map(function(idx, el) {
@@ -64,7 +64,7 @@ EmptyForm = Backbone.View.extend({
             return newEl.get();
         });
     }
-})
+});
 
 ListItemView = Backbone.View.extend({
     tagName: "div",
@@ -107,7 +107,7 @@ ListView = Backbone.View.extend({
     collection_class: ItemList,
     initialize: function() {
         if (!this.collection) {
-            this.collection = new this.collection_class;
+            this.collection = new this.collection_class();
             this.collection.parseForm(this.options.namespace);
         }
         this.options.managementForm = new ManagementForm({
@@ -165,7 +165,7 @@ SortableListView = ListView.extend({
             return this.collection.getByCid($(item).attr('id'));
         }, this));
         _.each(models, _.bind(function(model, idx, list) {
-            args = {}
+            args = {};
             args[this.model_order_attribute] = idx;
             model.set(args);
         }, this));

--- a/armstrong/hatband/static/hatband/js/backbone-inline-base.js
+++ b/armstrong/hatband/static/hatband/js/backbone-inline-base.js
@@ -78,8 +78,12 @@ ListItemView = Backbone.View.extend({
         var html = this.options.template(this.model.toJSON());
         $(this.el).html(html);
         if (this.model.get("hatband_display") === undefined) {
+            queryparams = {
+                'content_type': this.model.attributes.content_type,
+                'object_id': this.model.attributes.object_id,
+                'template': this.model.attributes.template};
             $.get(this.options.preview_url,
-                  this.model.attributes,
+                  queryparams,
                   _.bind(function(data, status, jqXHR) {
                       this.model.set({hatband_display: data});
                   }, this),

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -20,7 +20,7 @@ EXCLUDED_MODELS_FROM_FACETS = getattr(settings,
 
 EXCLUDED_APPS_FROM_FACETS = getattr(settings,
     "ARMSTRONG_EXCLUDED_APPS_FROM_FACETS", [
-        "admin", "arm_access", "auth", "contenttype", "djcelery",
+        "admin", "arm_access", "auth", "contenttypes", "djcelery",
         "registration", "reversion", "sessions", "sites", "south"
     ])
 

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -11,15 +11,16 @@ from ..http import JsonResponse
 
 EXCLUDED_MODELS_FROM_FACETS = getattr(settings,
     "ARMSTRONG_EXCLUDED_MODELS_FROM_FACETS", [
-        ("arm_wells", "welltype"),
-
-        # remove this next line if we decide to support this
+        # usage: ("app_label", "model_name"),
+        ('taggit', 'taggeditem'),
         ("arm_wells", "well"),
+        ("arm_wells", "node"),
     ])
 
 EXCLUDED_APPS_FROM_FACETS = getattr(settings,
     "ARMSTRONG_EXCLUDED_APPS_FROM_FACETS", [
-        "admin", "auth", "contenttype", "reversion", "sessions", "sites",
+        "admin", "arm_access", "auth", "contenttype", "djcelery",
+        "registration", "reversion", "sessions", "sites", "south"
     ])
 
 

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -108,8 +108,8 @@ class ModelPreviewMixin(ArmstrongBaseMixin):
         return urlpatterns + super(ModelPreviewMixin, self).get_urls()
 
     def render_model_preview(self, request):
-        type = ContentType.objects.get(pk=request.GET["content_type"])
-        model = type.model_class().objects.get(pk=request.GET["object_id"])
+        content_type = ContentType.objects.get(pk=request.GET["content_type"])
+        model = content_type.model_class().objects.get(pk=request.GET["object_id"])
         template = request.GET.get("template", "preview")
         return HttpResponse(render_model(model, template))
 

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -114,9 +114,9 @@ class ModelPreviewMixin(ArmstrongBaseMixin):
 
     def render_model_preview(self, request):
         try:
-            content_type_id = request.GET["content_type"]
-            object_id = request.GET["object_id"]
-        except KeyError:
+            content_type_id = int(request.GET["content_type"])
+            object_id = int(request.GET["object_id"])
+        except (ValueError, KeyError):
             return HttpResponseBadRequest()
 
         try:

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -82,6 +82,9 @@ class ModelSearchBackfillMixin(object):
         """
         Find instances for the requested model and return them as JSON.
         # TODO: add test coverage for this
+
+        We don't have to worry about invalid app_label/model_name parameters
+        because the URLs are pre-built with the kwargs in `get_urls()`.
         """
         content_type = ContentType.objects.get(app_label=app_label,
                 model=model_name)
@@ -143,8 +146,8 @@ class TypeAndModelQueryMixin(ArmstrongBaseMixin):
         """
         try:
             content_type = ContentType.objects.get(
-                    pk=request.GET.get("content_type_id"))
-        except ContentType.DoesNotExist:
+                    pk=request.GET["content_type_id"])
+        except (KeyError, ContentType.DoesNotExist):
             return HttpResponseBadRequest()
 
         try:


### PR DESCRIPTION
The commits are pretty self-explanatory, but two additional notes.

When a well node rendered a preview of itself, it made a request with unnecessary parameters. It actually used all the parameters it had. While that didn't cause a problem because the extra params were not used in the Python view, this is cleaner. The "DELETE" param was the troublesome thing that got me looking at this.

example: `http://site.com/admin/armstrong/search/?prefix=nodes-5-&order=10&content_type=64&object_id=32661&well=5&id=163&DELETE=`

The second update is to `render_model_preview()` so it returns HTTP error responses. `type_and_model_to_query()` is also updated to match with more accurate error responses.