### PR TITLE
Modifications to smooth Django 1.5/1.6 compatibility

### DIFF
--- a/armstrong/hatband/templates/admin/edit_inline/backbone.html
+++ b/armstrong/hatband/templates/admin/edit_inline/backbone.html
@@ -21,7 +21,7 @@
     <div id='{{ namespace }}-forms'>
     {% for inline_admin_form in inline_admin_formset.formset.initial_forms %}
     <div id='{{ inline_admin_form.prefix }}' class='{{ namespace }}-object'>
-        {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+        {% if inline_admin_form.has_auto_field or needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
         {{ inline_admin_form.fk_field.field }}
         {% spaceless %}
         {% for field in inline_admin_form %}

--- a/armstrong/hatband/templates/admin/edit_inline/generickey.html
+++ b/armstrong/hatband/templates/admin/edit_inline/generickey.html
@@ -17,7 +17,7 @@
         <tr class="{% cycle "row1" "row2" %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last %} empty-form{% endif %}"
              id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
         <td class="original">
-          {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {{ inline_admin_form.fk_field.field }}
           {% spaceless %}
           {% for fieldset in inline_admin_form %}

--- a/armstrong/hatband/tests/hatband_support/urls.py
+++ b/armstrong/hatband/tests/hatband_support/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, include, url
+try:
+    from django.conf.urls import patterns, include, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, include, url
 
 from armstrong import hatband as admin
 admin.autodiscover()

--- a/armstrong/hatband/views/search.py
+++ b/armstrong/hatband/views/search.py
@@ -1,11 +1,15 @@
-from armstrong.core.arm_layout.utils import render_model
 from django.conf import settings
-from django.conf.urls.defaults import patterns
-from django.conf.urls.defaults import url
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
+
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
+
+from armstrong.core.arm_layout.utils import render_model
 
 from ..http import JsonResponse
 


### PR DESCRIPTION
- Changes `django.core.url` imports to be forward compatible w/ Django 1.6+.
  - Tries the new import path, then catches `ImportError` on failure and tries the old import path.
- Modify inline templates to handle slight Django 1.6+ backwards incompatibility
  - In https://code.djangoproject.com/ticket/13696 (which was applied to Django 1.7 and backported to Django 1.6), `django.contrib.admin.helpers.InlineAdminForm.has_auto_field` was changed to `needs_explicit_pk_field`.